### PR TITLE
Fix to init Slider.Value after Mininum and Maximum

### DIFF
--- a/Xamarin.Forms.Platform.WinForms/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.WinForms/Renderers/SliderRenderer.cs
@@ -23,9 +23,9 @@ namespace Xamarin.Forms.Platform.WinForms
 
 				Control.TickFrequency = 0;
 
-				UpdateValue();
-				UpdateMinimum();
-				UpdateMaximum();
+                UpdateMinimum();
+                UpdateMaximum();
+                UpdateValue();				
 			}
 
 			base.OnElementChanged(e);


### PR DESCRIPTION
In order to set the Value property at initialization the Minimum and Maximum have to be set first.